### PR TITLE
Make sync wrapper fork-safe

### DIFF
--- a/postmark/sync.py
+++ b/postmark/sync.py
@@ -21,6 +21,7 @@ Example::
 
 import asyncio
 import inspect
+import os
 import threading
 from typing import Optional
 
@@ -32,12 +33,33 @@ class _EventLoopThread:
     """Persistent background thread running a dedicated event loop."""
 
     def __init__(self):
-        self._loop = asyncio.new_event_loop()
-        t = threading.Thread(target=self._loop.run_forever, daemon=True)
-        t.start()
+        self._lock = threading.Lock()
+        self._loop = None
+        self._thread = None
+        self._pid = None
+
+    def _ensure_started(self):
+        current_pid = os.getpid()
+        with self._lock:
+            if (
+                self._pid == current_pid
+                and self._loop is not None
+                and not self._loop.is_closed()
+                and self._thread is not None
+                and self._thread.is_alive()
+            ):
+                return
+
+            self._loop = asyncio.new_event_loop()
+            self._thread = threading.Thread(
+                target=self._loop.run_forever, daemon=True
+            )
+            self._thread.start()
+            self._pid = current_pid
 
     def run(self, coro):
         """Submit a coroutine and block the calling thread until it returns or raises."""
+        self._ensure_started()
         return asyncio.run_coroutine_threadsafe(coro, self._loop).result()
 
 

--- a/tests/test_sync_client.py
+++ b/tests/test_sync_client.py
@@ -1,5 +1,8 @@
 """Tests for postmark.sync — synchronous wrapper around the async clients."""
 
+import os
+import select
+import signal
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -262,3 +265,39 @@ class TestModuleLevelLoop:
 
         result = postmark.sync._loop.run(echo("hello"))
         assert result == "hello"
+
+    @pytest.mark.skipif(not hasattr(os, "fork"), reason="requires os.fork")
+    def test_module_loop_recovers_after_fork(self):
+        async def echo(value):
+            return value
+
+        assert postmark.sync._loop.run(echo("parent")) == "parent"
+
+        read_fd, write_fd = os.pipe()
+        pid = os.fork()
+        if pid == 0:
+            os.close(read_fd)
+            try:
+                result = postmark.sync._loop.run(echo("child"))
+                os.write(write_fd, result.encode())
+            except Exception as exc:
+                os.write(write_fd, f"ERROR:{exc}".encode())
+            finally:
+                os.close(write_fd)
+            os._exit(0)
+
+        os.close(write_fd)
+        try:
+            ready, _, _ = select.select([read_fd], [], [], 2)
+            if not ready:
+                os.kill(pid, signal.SIGKILL)
+                os.waitpid(pid, 0)
+                pytest.fail("module event loop hung after fork")
+
+            payload = os.read(read_fd, 1024).decode()
+            _, status = os.waitpid(pid, 0)
+        finally:
+            os.close(read_fd)
+
+        assert status == 0
+        assert payload == "child"


### PR DESCRIPTION
## Summary

Fix `postmark.sync` so its background event-loop thread is safe to use after a process fork.

The sync wrapper currently creates a module-level event-loop thread at import time. In prefork servers, such as Odoo/Gunicorn-style worker deployments, importing `postmark.sync` before worker fork leaves child processes with a reference to an event loop whose thread no longer exists. A later sync call schedules a coroutine onto that stale loop and waits forever.

This change makes `_EventLoopThread` lazy and fork-aware. Before each run it checks the current PID and thread liveness, and starts a fresh event loop thread when needed.

## Root Cause

`asyncio.run_coroutine_threadsafe(...).result()` blocks indefinitely if the target loop is not running. After `fork()`, the background loop thread created before the fork is gone in the child process, but the module-level `_loop` object still points to the old loop.

## Changes

- Start the sync wrapper event-loop thread lazily.
- Track the PID that owns the loop thread.
- Recreate the event loop thread when the PID changes or the thread is no longer alive.
- Add a regression test that starts the module loop before `fork()` and verifies the child can still run a sync call.

## Validation

- `UV_CACHE_DIR=/tmp/uv-cache uv run --with-editable . --with pytest --with pytest-asyncio --with httpx --with pydantic --with email-validator --with tenacity --with respx pytest`
- Result: `417 passed, 1 warning`

The warning is Python's expected `os.fork()` deprecation warning for multithreaded processes, which is exactly the deployment class this regression protects.
