### PR TITLE
feat: add PEP 561 py.typed marker and sync trove classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,11 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Communications :: Email",
     "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
 ]
 
 [tool.poetry.urls]


### PR DESCRIPTION
Add the py.typed marker so the package's existing type annotations can be used by type checkers in downstream projects. Include the "Typing :: Typed" classifier and Python 3.13/3.14 classifiers to match CI.

Per PEP 561, a type checker uses a package's inline annotations only if the package opts in with this marker: maintainers "MUST add a marker file named py.typed", and bundled types "SHOULD be used" only for packages that have done so. This code was already annotated but never shipped the marker, so conformant checkers ignore those types. Adding the empty file fixes that, with no runtime or public API change.
