### PR TITLE
chore: migrate pyproject metadata to PEP 621 [project] table

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1220,5 +1220,5 @@ typing-extensions = {version = ">=4.13.2", markers = "python_version < \"3.11\""
 
 [metadata]
 lock-version = "2.1"
-python-versions = "^3.10"
-content-hash = "d31c16857068187b0aeabc0c66bed4f671bab51cefc80f18c6c43af3f627ce93"
+python-versions = ">=3.10,<4.0"
+content-hash = "6ea13441149f4d993c1050a3afbce43e361e74deeb09282815f13f800f40c31b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,17 @@
-[tool.poetry]
+[project]
 name = "postmark-python"
 version = "0.3.3"
 description = "The Official Postmark Python SDK."
-authors = ["Greg Svoboda <gsvoboda@activecampaign.com>"]
+authors = [
+    { name = "Greg Svoboda", email = "gsvoboda@activecampaign.com" },
+]
 license = "MIT"
+license-files = ["LICENSE"]
 readme = "README.md"
-packages = [{include = "postmark"}]
-repository = "https://github.com/ActiveCampaign/postmark-python"
-homepage = "https://postmarkapp.com/developer/integration/official-libraries"
-documentation = "https://github.com/ActiveCampaign/postmark-python/wiki"
+requires-python = ">=3.10,<4.0"
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -23,16 +22,22 @@ classifiers = [
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
 ]
+dependencies = [
+    "httpx>=0.28.1,<0.29.0",          # concurrency (async) and HTTP requests
+    "pydantic>=2.6.0,<3.0.0",         # type safety and validation
+    "email-validator>=2.1.1,<3.0.0",  # required by pydantic.EmailStr for email format validation
+    "tenacity>=8.2.3,<9.0.0",         # resilience and retry logic
+]
 
-[tool.poetry.urls]
-"Issues" = "https://github.com/ActiveCampaign/postmark-python/issues"
+[project.urls]
+Homepage = "https://postmarkapp.com/developer/integration/official-libraries"
+Repository = "https://github.com/ActiveCampaign/postmark-python"
+Documentation = "https://github.com/ActiveCampaign/postmark-python/wiki"
+Issues = "https://github.com/ActiveCampaign/postmark-python/issues"
 
-[tool.poetry.dependencies]
-python = "^3.10"
-httpx = "^0.28.1"             # Concurrency (async) and HTTP requests
-pydantic = "^2.6.0"           # Type safety and validation
-email-validator = "^2.1.1"    # REQUIRED by pydantic.EmailStr for email format validation
-tenacity = "^8.2.3"           # Resilience and retry logic
+# Poetry-specific build config; package dir differs from the normalized project name.
+[tool.poetry]
+packages = [{ include = "postmark" }]
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^8.1.1"             # Testing framework
@@ -43,9 +48,6 @@ mypy = "^2.1.0"
 ruff = "^0.15.0"
 pre-commit = "^4.0.0"
 python-dotenv = "^1.2.2"
-
-
-
 
 [tool.ruff]
 line-length = 88
@@ -69,5 +71,5 @@ exclude_dirs = ["tests"]
 omit = ["*/enums.py"]
 
 [build-system]
-requires = ["poetry-core"]
+requires = ["poetry-core>=2.4.0,<3.0.0"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
This PR addresses the output of the `poetry check` command which currently reports multiple deprecation warnings (and fails under `poetry check --strict`). Poetry 2.0 deprecated the legacy `[tool.poetry]` metadata format and adopted the PEP 621 `[project]` table as the standard way to declare package metadata.

Poetry plans to drop this old format, so addressing it now prevents the build from breaking once that support is gone. It also moves the package onto PEP 621, the standard metadata format that build tools can read directly.

```bash
Warning: [tool.poetry.name] is deprecated. Use [project.name] instead.
Warning: [tool.poetry.version] is set but 'version' is not in [project.dynamic]. If it is static use [project.version]. If it is dynamic, add 'version' to [project.dynamic].
If you want to set the version dynamically via `poetry build --local-version` or you are using a plugin, which sets the version dynamically, you should define the version in [tool.poetry] and add 'version' to [project.dynamic].
Warning: [tool.poetry.description] is deprecated. Use [project.description] instead.
Warning: [tool.poetry.readme] is set but 'readme' is not in [project.dynamic]. If it is static use [project.readme]. If it is dynamic, add 'readme' to [project.dynamic].
If you want to define multiple readmes, you should define them in [tool.poetry] and add 'readme' to [project.dynamic].
Warning: [tool.poetry.license] is deprecated. Use [project.license] instead.
Warning: [tool.poetry.authors] is deprecated. Use [project.authors] instead.
Warning: [tool.poetry.classifiers] is set but 'classifiers' is not in [project.dynamic]. If it is static use [project.classifiers]. If it is dynamic, add 'classifiers' to [project.dynamic].
ATTENTION: Per default Poetry determines classifiers for supported Python versions and license automatically. If you define classifiers in [project], you disable the automatic enrichment. In other words, you have to define all classifiers manually. If you want to use Poetry's automatic enrichment of classifiers, you should define them in [tool.poetry] and add 'classifiers' to [project.dynamic].
Warning: [tool.poetry.homepage] is deprecated. Use [project.urls] instead.
Warning: [tool.poetry.repository] is deprecated. Use [project.urls] instead.
Warning: [tool.poetry.documentation] is deprecated. Use [project.urls] instead.
Warning: [tool.poetry.urls] is deprecated. Use [project.urls] instead.
Warning: License classifiers are deprecated. Use [project.license] instead.
```

This is a followup from https://github.com/ActiveCampaign/postmark-python/pull/9 dev tooling update, which effectively updated `poetry.lock` file from Poetry 1.8.3 to Poetry 2.4.1

`pyproject.toml` file now passes under `poetry check --strict`