### PR TITLE
Fix inactive recipient email parsing

### DIFF
--- a/postmark/exceptions.py
+++ b/postmark/exceptions.py
@@ -78,7 +78,7 @@ class InactiveRecipientException(PostmarkAPIException):
         request_id: str | None = None,
     ):
         super().__init__(message, error_code, http_status, request_id)
-        match = re.search(r"Found inactive addresses: ([^.]+)", message)
+        match = re.search(r"Found inactive addresses:\s*(.+?)\.(?:\s|$)", message)
         self.inactive_recipients: list[str] = (
             [a for addr in match.group(1).split(",") if (a := addr.strip())]
             if match

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,40 @@
+"""Tests for Postmark exception helpers."""
+
+import pytest
+
+from postmark.exceptions import InactiveRecipientException
+
+
+@pytest.mark.parametrize(
+    ("message", "expected"),
+    [
+        (
+            "Found inactive addresses: john@example.com. Emails to these addresses "
+            "are not accepted or delivered by Postmark.",
+            ["john@example.com"],
+        ),
+        (
+            "Found inactive addresses: john@example.com, jane@test.org. Emails to "
+            "these addresses are not accepted or delivered by Postmark.",
+            ["john@example.com", "jane@test.org"],
+        ),
+        (
+            "Found inactive addresses: a@example.co, b@example.io, c@example.net.",
+            ["a@example.co", "b@example.io", "c@example.net"],
+        ),
+        (
+            "Found inactive addresses:john@example.com.",
+            ["john@example.com"],
+        ),
+        (
+            "Inactive recipient.",
+            [],
+        ),
+    ],
+)
+def test_inactive_recipient_exception_parses_inactive_recipients(
+    message: str, expected: list[str]
+):
+    exc = InactiveRecipientException(message, error_code=406, http_status=406)
+
+    assert exc.inactive_recipients == expected


### PR DESCRIPTION
Fixes InactiveRecipientException parsing so email domains are not truncated at the first period. Adds coverage for single and multiple inactive recipients.